### PR TITLE
Handle edge-case of missing TXT record

### DIFF
--- a/src/dkim/verify_mail.cr
+++ b/src/dkim/verify_mail.cr
@@ -54,11 +54,17 @@ module Dkim
       #delta = after-before
       #puts "Timing: #{delta}"
 
-      first_answers = packets[1][0].answers
-      ares = first_answers.select {|c| c.class == DNS::Records::TXT }[0]
-      return nil unless ares # Can have none...
-      txt_record = ares.as(DNS::Records::TXT)
-      return txt_record
+      if packets.empty?
+        puts "No DNS response for #{record}"
+        return nil
+      else
+        first_answers = packets[1]?[0]?&.answers?
+        return nil unless first_answers
+        ares = first_answers.select {|c| c.class == DNS::Records::TXT }[0]
+        return nil unless ares # Can have none...
+        txt_record = ares.as(DNS::Records::TXT)
+        return txt_record
+      end
     end
 
     def verify(dns_server_ips : Array(String) = ["8.8.8.8", "4.2.2.2", "1.1.1.1"])


### PR DESCRIPTION
Fixes #2 

- Checks if the packet received from the DNS resolver is empty before attempting to access it
- Adds safe indexing and safe navigation operators when parsing the packet (in case a packet exists but is malformed)