### PR TITLE
v0.4.0: Fix deprecated DNS API

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: dkim
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   openssl_ext:

--- a/src/dkim/verify_mail.cr
+++ b/src/dkim/verify_mail.cr
@@ -47,7 +47,7 @@ module Dkim
     end
 
     def query_google_for_txt_record(dns_resolver, record)
-      ask_packet = DNS::Packet.create_getaddrinfo_ask protocol_type: DNS::ProtocolType::UDP, name: record, record_type: DNS::Packet::RecordFlag::TXT, class_type: DNS::Packet::ClassFlag::Internet
+      ask_packet = DNS::Packet.create_query_packet protocol_type: DNS::ProtocolType::UDP, name: record, record_type: DNS::Packet::RecordFlag::TXT, class_type: DNS::Packet::ClassFlag::Internet
       packets = dns_resolver.resolve host: record, record_type: DNS::Packet::RecordFlag::TXT, ask_packet: ask_packet
 
       if packets.empty?


### PR DESCRIPTION
## Summary
- Replace deprecated `DNS::Packet.create_getaddrinfo_ask` with `create_query_packet`
- Bump version to 0.4.0

## Test plan
- [x] `crystal spec` — 29 examples, 0 failures, no deprecation warnings
- [ ] CI passes on GitHub Actions